### PR TITLE
Remove unnecessary clones and allocations.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,13 +33,17 @@ pub fn get<T: Into<String>>(input_language: T) -> Vec<String> {
         .expect("Could not read JSON file from Stopwords ISO.");
 
     // Get the words
-    json.get(language_name_as_string.clone())
+    json.get(&language_name_as_string)
         .unwrap_or_else(|| panic!("The '{language_name_as_string}' language is not recognized. Please check the documentation for a supported list of languages."))
-        .clone()
-        .as_array_mut()
+        .as_array()
         .expect("The referenced value is not a mutable array.")
         .iter()
-        .map(serde_json::Value::to_string)
-        .map(|x| x.replace("\"", ""))
+        .map(|x| {
+            if let serde_json::Value::String(s) = x {
+                s.to_owned()
+            } else {
+                panic!("The referenced value is not a string.")
+            }
+        })
         .collect()
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,18 +29,20 @@ pub fn get<T: Into<String>>(input_language: T) -> Vec<String> {
     };
 
     // Get the JSON
-    let json: serde_json::Value = serde_json::from_slice(json_as_bytes)
+    let mut json: serde_json::Value = serde_json::from_slice(json_as_bytes)
         .expect("Could not read JSON file from Stopwords ISO.");
 
     // Get the words
-    json.get(&language_name_as_string)
+    json.get_mut(&language_name_as_string)
+        .take()
         .unwrap_or_else(|| panic!("The '{language_name_as_string}' language is not recognized. Please check the documentation for a supported list of languages."))
-        .as_array()
+        .as_array_mut()
         .expect("The referenced value is not a mutable array.")
-        .iter()
+        .iter_mut()
         .map(|x| {
+            let x = x.take();
             if let serde_json::Value::String(s) = x {
-                s.to_owned()
+                s
             } else {
                 panic!("The referenced value is not a string.")
             }


### PR DESCRIPTION
This should reduce the number of allocations to ~~just `N+O(1)`~~ the minimum overhead required for parsing JSON.

One more allocation can be removed with a breaking change so I haven't included that change here, but the signature of `stop_words::get` could easily be changed to accept a `AsRef<str>` instead of a `Into<String>`.

https://github.com/cmccomb/rust-stop-words/blob/66711b9b2c5f65af57f4ed15384970b4c1c3e809/src/lib.rs#L18