### PR TITLE
Generate stopword slices at build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,12 +17,12 @@ default = ["iso"]
 iso = []
 nltk = []
 constructed = []
+unimplemented = []
 
 [build-dependencies]
 serde_json = {version="^1"}
 
 [dependencies]
-serde_json = {version="^1"}
 
 [dev-dependencies]
 human_regex = "^0.3.0"

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ This crate supports all languages from [Stopwords ISO](https://github.com/stopwo
 </details>
 
 # Constructed Language Availability
-We also support some constructed (fictional/fantasy) languages! Expand the table below to see a comprehensive description. ChatGPT was used to generate these lists quickly, so they are incomplete and approximate. Help welcome! To use these languages, add the `constructed` feature.
+We also support some constructed (fictional/fantasy) languages! Expand the table below to see a comprehensive description. `ChatGPT` was used to generate these lists quickly, so they are incomplete and approximate. Help welcome! To use these languages, add the `constructed` feature.
 
 <details>
     <summary>Language Coverage Table</summary>
@@ -233,7 +233,7 @@ We also support some constructed (fictional/fantasy) languages! Expand the table
 | mis (_nav_ is used here) | [Navi](https://en.wikipedia.org/wiki/Na%CA%BCvi_language)                                   | 
 | mis (_val_ is used here) | [High Valyrian](https://en.wikipedia.org/wiki/Valyrian_languages)                           |
 
-The following prompt was used with the Mar 14, 2023 version of ChatGPT:
+The following prompt was used with the Mar 14, 2023 version of `ChatGPT`:
 ```text
 Please give me one list of 20+ stop words for each of the following languages: Sindarin, Quenya, Dothraki, Na'vi, 
 Dovahzul, Klingon, and High Valyrian. I'd like the lists to be formatted as follows:

--- a/build.rs
+++ b/build.rs
@@ -1,71 +1,119 @@
-use std::collections::HashMap;
-use std::io::Write;
-
-fn construct_json(languages: Vec<(&str, &str)>, file_name: &str) {
-    // Make a json structure and populate it with file information
-    let mut json_struct: HashMap<String, Vec<String>> = HashMap::new();
-    for lingo in languages {
-        let iso_code = lingo.0.to_string();
-        let stop_word_set = lingo
-            .1
-            .split('\n')
-            .map(String::from)
-            .collect::<Vec<String>>();
-        json_struct.insert(iso_code, stop_word_set);
+fn write_language(out: &mut String, match_arms: &mut Vec<String>, code: &str, words: &[&str]) {
+    let constant_name = code.to_uppercase();
+    out.push_str("static ");
+    out.push_str(&constant_name);
+    out.push_str(": [&str; ");
+    out.push_str(&words.len().to_string());
+    out.push_str("] = [");
+    for word in words {
+        out.push('"');
+        out.push_str(&word.escape_default().to_string());
+        out.push_str("\",");
     }
-
-    // Convert to a JSON string
-    let json_string: String = serde_json::to_string(&json_struct).unwrap();
-
-    // Save the string
-    let mut json_file =
-        std::fs::File::create(std::env::var("OUT_DIR").unwrap() + "/" + file_name).unwrap();
-    write!(json_file, "{json_string}").expect("Could not write JSON file.");
+    out.push_str("];\n");
+    match_arms.push(format!("        \"{code}\" => Some(&{constant_name}),\n"));
 }
 
 fn main() {
-    // Update on changes
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=src/nltk");
+    println!("cargo:rerun-if-changed=src/constructed");
+    println!("cargo:rerun-if-changed=src/iso/stopwords-iso.json");
 
-    // Information on file locations
-    let nltk_languages = vec![
-        ("ar", include_str!("src/nltk/arabic")),
-        ("az", include_str!("src/nltk/azerbaijani")),
-        ("da", include_str!("src/nltk/danish")),
-        ("nl", include_str!("src/nltk/dutch")),
-        ("en", include_str!("src/nltk/english")),
-        ("fi", include_str!("src/nltk/finnish")),
-        ("fr", include_str!("src/nltk/french")),
-        ("de", include_str!("src/nltk/german")),
-        ("el", include_str!("src/nltk/greek")),
-        ("hu", include_str!("src/nltk/hungarian")),
-        ("id", include_str!("src/nltk/indonesian")),
-        ("it", include_str!("src/nltk/italian")),
-        ("kk", include_str!("src/nltk/kazakh")),
-        ("ne", include_str!("src/nltk/nepali")),
-        ("no", include_str!("src/nltk/norwegian")),
-        ("pt", include_str!("src/nltk/portuguese")),
-        ("ro", include_str!("src/nltk/romanian")),
-        ("ru", include_str!("src/nltk/russian")),
-        ("sl", include_str!("src/nltk/slovenian")),
-        ("es", include_str!("src/nltk/spanish")),
-        ("sv", include_str!("src/nltk/swedish")),
-        ("tg", include_str!("src/nltk/tajik")),
-        ("tr", include_str!("src/nltk/turkish")),
-    ];
+    let mut file_contents = String::new();
+    let mut match_arms: Vec<String> = Vec::new();
 
-    // Information on file locations
-    let constructed_languages = vec![
-        ("dot", include_str!("src/constructed/dothraki")),
-        ("dov", include_str!("src/constructed/dovahzul")),
-        ("val", include_str!("src/constructed/highvalyrian")),
-        ("tlh", include_str!("src/constructed/klingon")),
-        ("qya", include_str!("src/constructed/quenya")),
-        ("sjn", include_str!("src/constructed/sindarin")),
-        ("nav", include_str!("src/constructed/navi")),
-    ];
+    let nltk = std::env::var("CARGO_FEATURE_NLTK").is_ok();
+    let constructed = std::env::var("CARGO_FEATURE_CONSTRUCTED").is_ok();
+    let iso = std::env::var("CARGO_FEATURE_ISO").is_ok();
 
-    construct_json(nltk_languages, "stopwords-nltk.json");
-    construct_json(constructed_languages, "stopwords-constructed.json");
+    let mut languages: std::collections::BTreeMap<
+        std::string::String,
+        std::vec::Vec<std::string::String>,
+    > = std::collections::BTreeMap::new();
+
+    if nltk {
+        let nltk_languages = vec![
+            ("ar", include_str!("src/nltk/arabic")),
+            ("az", include_str!("src/nltk/azerbaijani")),
+            ("da", include_str!("src/nltk/danish")),
+            ("nl", include_str!("src/nltk/dutch")),
+            ("en", include_str!("src/nltk/english")),
+            ("fi", include_str!("src/nltk/finnish")),
+            ("fr", include_str!("src/nltk/french")),
+            ("de", include_str!("src/nltk/german")),
+            ("el", include_str!("src/nltk/greek")),
+            ("hu", include_str!("src/nltk/hungarian")),
+            ("id", include_str!("src/nltk/indonesian")),
+            ("it", include_str!("src/nltk/italian")),
+            ("kk", include_str!("src/nltk/kazakh")),
+            ("ne", include_str!("src/nltk/nepali")),
+            ("no", include_str!("src/nltk/norwegian")),
+            ("pt", include_str!("src/nltk/portuguese")),
+            ("ro", include_str!("src/nltk/romanian")),
+            ("ru", include_str!("src/nltk/russian")),
+            ("sl", include_str!("src/nltk/slovenian")),
+            ("es", include_str!("src/nltk/spanish")),
+            ("sv", include_str!("src/nltk/swedish")),
+            ("tg", include_str!("src/nltk/tajik")),
+            ("tr", include_str!("src/nltk/turkish")),
+        ];
+        for (code, data) in nltk_languages {
+            let words: std::vec::Vec<std::string::String> = data
+                .split('\n')
+                .filter(|w| !w.is_empty())
+                .map(std::string::String::from)
+                .collect();
+            languages.insert(code.to_string(), words);
+        }
+    }
+
+    if constructed {
+        let constructed_languages = vec![
+            ("dot", include_str!("src/constructed/dothraki")),
+            ("dov", include_str!("src/constructed/dovahzul")),
+            ("val", include_str!("src/constructed/highvalyrian")),
+            ("tlh", include_str!("src/constructed/klingon")),
+            ("qya", include_str!("src/constructed/quenya")),
+            ("sjn", include_str!("src/constructed/sindarin")),
+            ("nav", include_str!("src/constructed/navi")),
+        ];
+        for (code, data) in constructed_languages {
+            let words: std::vec::Vec<std::string::String> = data
+                .split('\n')
+                .filter(|w| !w.is_empty())
+                .map(std::string::String::from)
+                .collect();
+            languages.insert(code.to_string(), words);
+        }
+    }
+
+    if iso {
+        let json_data = std::fs::read_to_string("src/iso/stopwords-iso.json").unwrap();
+        let parsed: std::collections::BTreeMap<
+            std::string::String,
+            std::vec::Vec<std::string::String>,
+        > = serde_json::from_str(&json_data).unwrap();
+        for (code, words_vec) in parsed {
+            languages.entry(code).or_insert(words_vec);
+        }
+    }
+
+    for (code, words_vec) in languages {
+        let words: std::vec::Vec<&str> =
+            words_vec.iter().map(std::string::String::as_str).collect();
+        write_language(&mut file_contents, &mut match_arms, &code, &words);
+    }
+
+    file_contents.push_str(
+        "pub(crate) fn lookup(language: &str) -> Option<&'static [&'static str]> {\n    match language {\n",
+    );
+    for arm in match_arms {
+        file_contents.push_str(&arm);
+    }
+    file_contents.push_str("        _ => None,\n    }\n}\n");
+
+    let out_dir = std::env::var("OUT_DIR").unwrap();
+    let out_path = std::path::Path::new(&out_dir).join("stopwords.rs");
+    std::fs::write(out_path, file_contents).unwrap();
 }

--- a/examples/remove_stop_words_with_regex.rs
+++ b/examples/remove_stop_words_with_regex.rs
@@ -1,33 +1,38 @@
-use human_regex::{exactly, one_or_more, or, punctuation, whitespace, word_boundary};
-use stop_words::{get, LANGUAGE};
-
+// This example demonstrates removing stop words using regular expressions.
+// It is only built when ISO or NLTK stop words are available and constructed languages are disabled.
+#[cfg(all(any(feature = "nltk", feature = "iso"), not(feature = "constructed")))]
 fn main() {
-    #[cfg(all(any(feature = "nltk", feature = "iso"), not(feature = "constructed")))]
-    {
-        // Read in a file
-        let document = std::fs::read_to_string("examples/foreword.txt").expect("Cannot read file");
+    // Read in a file
+    let document = std::fs::read_to_string("examples/foreword.txt").expect("Cannot read file");
 
-        // Print the contents
-        println!("Original text:\n{}", document);
+    // Print the contents
+    println!("Original text:\n{}", document);
 
-        // Get the stopwords
-        let words = get(LANGUAGE::English);
+    // Get the stopwords
+    let words = stop_words::get(stop_words::LANGUAGE::English);
 
-        // Remove punctuation and lowercase the text to make parsing easier
-        let lowercase_doc = document.to_ascii_lowercase();
-        let regex_for_punctuation = one_or_more(punctuation());
-        let text_without_punctuation = regex_for_punctuation
-            .to_regex()
-            .replace_all(&lowercase_doc, "");
+    // Remove punctuation and lowercase the text to make parsing easier
+    let lowercase_doc = document.to_ascii_lowercase();
+    let regex_for_punctuation = human_regex::one_or_more(human_regex::punctuation());
+    let text_without_punctuation = regex_for_punctuation
+        .to_regex()
+        .replace_all(&lowercase_doc, "");
 
-        // Make a regex to match stopwords with trailing spaces and punctuation
-        let regex_for_stop_words =
-            word_boundary() + exactly(1, or(&words)) + word_boundary() + one_or_more(whitespace());
+    // Make a regex to match stopwords with trailing spaces and punctuation
+    let regex_for_stop_words = human_regex::word_boundary()
+        + human_regex::exactly(1, human_regex::or(&words))
+        + human_regex::word_boundary()
+        + human_regex::one_or_more(human_regex::whitespace());
 
-        // Remove stop words
-        let clean_text = regex_for_stop_words
-            .to_regex()
-            .replace_all(&text_without_punctuation, "");
-        println!("\nClean text:\n{}", clean_text);
-    }
+    // Remove stop words
+    let clean_text = regex_for_stop_words
+        .to_regex()
+        .replace_all(&text_without_punctuation, "");
+    println!("\nClean text:\n{}", clean_text);
 }
+
+#[cfg(any(
+    all(not(feature = "nltk"), not(feature = "iso")),
+    feature = "constructed"
+))]
+fn main() {}

--- a/src/language_names.rs
+++ b/src/language_names.rs
@@ -288,6 +288,7 @@ pub enum LANGUAGE {
 impl LANGUAGE {
     /// Return the ISO language code for this variant.
     #[must_use]
+    #[allow(clippy::too_many_lines)]
     pub const fn as_str(&self) -> &'static str {
         match self {
             #[cfg(all(any(feature = "nltk", feature = "iso"), not(feature = "constructed")))]


### PR DESCRIPTION
## Summary
- build stopword lists into static slices during compilation
- expose `get` as a zero-allocation lookup returning a static slice
- clean up docs and examples, drop runtime `serde_json` dependency

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test --all-features`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68a8eb6a24748325a2b3d21bba588daa