### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stop-words"
-version = "0.8.1"
+version = "0.9.0"
 authors = ["Chris McComb <ccmcc2012@gmail.com>"]
 description = "Common stop words in many languages"
 edition = "2021"


### PR DESCRIPTION
## Summary
- bump crate version to 0.9.0

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings -W clippy::pedantic`
- `cargo test -q`
- `cargo publish` *(fails: no token found)*

------
https://chatgpt.com/codex/tasks/task_e_68a8f0149c1c8325a34627c38fb298d3